### PR TITLE
Creature Template

### DIFF
--- a/1-19/creature_template.sql
+++ b/1-19/creature_template.sql
@@ -1,0 +1,724 @@
+-- Stormwind City Guard
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=68;
+-- Kobold Laborer
+UPDATE `creature_template` SET `minlevel`=3, `maxlevel`=4 WHERE `entry`=80;
+-- Riverpaw Overseer
+UPDATE `creature_template` SET `minlevel`=19, `maxlevel`=19 WHERE `entry`=125;
+-- Zzarc' Vul
+UPDATE `creature_template` SET `minlevel`=30, `maxlevel`=30 WHERE `entry`=300;
+-- Stalvan Mistmantle
+UPDATE `creature_template` SET `minlevel`=32, `maxlevel`=32 WHERE `entry`=315;
+-- Dungar Longdrink
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=352;
+-- Morganth
+UPDATE `creature_template` SET `minlevel`=27, `maxlevel`=27 WHERE `entry`=397;
+-- Redridge Alpha
+UPDATE `creature_template` SET `minlevel`=21, `maxlevel`=22 WHERE `entry`=445;
+-- Redridge Basher
+UPDATE `creature_template` SET `minlevel`=19, `maxlevel`=20 WHERE `entry`=446;
+-- General Marcus Jonathan
+UPDATE `creature_template` SET `minlevel`=62, `maxlevel`=62 WHERE `entry`=466;
+-- Yowler
+UPDATE `creature_template` SET `minlevel`=25, `maxlevel`=25 WHERE `entry`=518;
+-- Mor'Ladim
+UPDATE `creature_template` SET `minlevel`=35, `maxlevel`=35 WHERE `entry`=522;
+-- Thor
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=523;
+-- Defias Messenger
+UPDATE `creature_template` SET `minlevel`=14, `maxlevel`=15 WHERE `entry`=550;
+-- Blackrock Tracker
+UPDATE `creature_template` SET `minlevel`=23, `maxlevel`=24 WHERE `entry`=615;
+-- Foreman Thistlenettle
+UPDATE `creature_template` SET `minlevel`=20, `maxlevel`=20 WHERE `entry`=626;
+-- Green Wyrmkin
+UPDATE `creature_template` SET `minlevel`=41, `maxlevel`=42 WHERE `entry`=742;
+-- Green Scalebane
+UPDATE `creature_template` SET `minlevel`=42, `maxlevel`=43 WHERE `entry`=744;
+-- Shadow Panther
+UPDATE `creature_template` SET `minlevel`=39, `maxlevel`=40 WHERE `entry`=768;
+-- Mai'Zoth
+UPDATE `creature_template` SET `minlevel`=47, `maxlevel`=47 WHERE `entry`=818;
+-- Coldridge Mountaineer
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=853;
+-- Stonard Grunt
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=866;
+-- Saltscale Oracle
+UPDATE `creature_template` SET `minlevel`=36, `maxlevel`=37 WHERE `entry`=873;
+-- Ariena Stormfeather
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=931;
+-- Kurzen Medicine Man
+UPDATE `creature_template` SET `minlevel`=32, `maxlevel`=33 WHERE `entry`=940;
+-- Dragonmaw Raider
+UPDATE `creature_template` SET `minlevel`=26, `maxlevel`=27 WHERE `entry`=1034;
+-- Dragonmaw Swamprunner
+UPDATE `creature_template` SET `minlevel`=27, `maxlevel`=28 WHERE `entry`=1035;
+-- Dragonmaw Centurion
+UPDATE `creature_template` SET `minlevel`=28, `maxlevel`=29 WHERE `entry`=1036;
+-- Dragonmaw Battlemaster
+UPDATE `creature_template` SET `minlevel`=30, `maxlevel`=30 WHERE `entry`=1037;
+-- Dragonmaw Shadowwarder
+UPDATE `creature_template` SET `minlevel`=28, `maxlevel`=29 WHERE `entry`=1038;
+-- Fen Dweller
+UPDATE `creature_template` SET `minlevel`=20, `maxlevel`=21 WHERE `entry`=1039;
+-- Dragonmaw Bonewarder
+UPDATE `creature_template` SET `minlevel`=27, `maxlevel`=28 WHERE `entry`=1057;
+-- Grom'gol Grunt
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=1064;
+-- Razormaw Matriarch
+UPDATE `creature_template` SET `minlevel`=30, `maxlevel`=30 WHERE `entry`=1140;
+-- Grif Wildheart
+UPDATE `creature_template` SET `minlevel`=8, `maxlevel`=12 WHERE `entry`=1231;
+-- Boran Ironclink
+UPDATE `creature_template` SET `minlevel`=8, `maxlevel`=11 WHERE `entry`=1240;
+-- Prospector Gehn
+UPDATE `creature_template` SET `minlevel`=8, `maxlevel`=12 WHERE `entry`=1255;
+-- Archbishop Benedictus
+UPDATE `creature_template` SET `minlevel`=63, `maxlevel`=63 WHERE `entry`=1284;
+-- Cook Ghilm
+UPDATE `creature_template` SET `minlevel`=8, `maxlevel`=11 WHERE `entry`=1355;
+-- Miner Grothor
+UPDATE `creature_template` SET `minlevel`=8, `maxlevel`=10 WHERE `entry`=1358;
+-- Miner Grumnal
+UPDATE `creature_template` SET `minlevel`=8, `maxlevel`=10 WHERE `entry`=1360;
+-- Balgaras the Foul
+UPDATE `creature_template` SET `minlevel`=34, `maxlevel`=34 WHERE `entry`=1364;
+-- Thysta
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=1387;
+-- Gorlash
+UPDATE `creature_template` SET `minlevel`=47, `maxlevel`=47 WHERE `entry`=1492;
+-- Mok'rash
+UPDATE `creature_template` SET `minlevel`=50, `maxlevel`=50 WHERE `entry`=1493;
+-- King Mukla
+UPDATE `creature_template` SET `minlevel`=51, `maxlevel`=51 WHERE `entry`=1559;
+-- Bloodsail Swashbuckler
+UPDATE `creature_template` SET `minlevel`=41, `maxlevel`=43 WHERE `entry`=1563;
+-- Bloodsail Warlock
+UPDATE `creature_template` SET `minlevel`=41, `maxlevel`=43 WHERE `entry`=1564;
+-- Bloodsail Sea Dog
+UPDATE `creature_template` SET `minlevel`=43, `maxlevel`=45 WHERE `entry`=1565;
+-- Shellei Brondir
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=1571;
+-- Thorgrum Borrelson
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=1572;
+-- Gryth Thurden
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=1573;
+-- Northshire Guard
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=1642;
+-- Bloodsail Elder Magus
+UPDATE `creature_template` SET `minlevel`=44, `maxlevel`=45 WHERE `entry`=1653;
+-- Deathguard Randolph
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=1736;
+-- Deathguard Oliver
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=1737;
+-- Deathguard Phillip
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=1739;
+-- Deathguard Bartrand
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=1741;
+-- Stormwind Royal Guard
+UPDATE `creature_template` SET `minlevel`=60, `maxlevel`=60 WHERE `entry`=1741;
+-- High Priest Thel'danis
+UPDATE `creature_template` SET `minlevel`=62, `maxlevel`=62 WHERE `entry`=1854;
+-- Thule Ravenclaw
+UPDATE `creature_template` SET `minlevel`=24, `maxlevel`=24 WHERE `entry`=1947;
+-- Deathguard Bartrand
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=1741;
+-- Stormwind Royal Guard
+UPDATE `creature_template` SET `minlevel`=60, `maxlevel`=60 WHERE `entry`=1756;
+-- Stormwind City Patroller
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=1976;
+-- Chieftain Nek'rosh
+UPDATE `creature_template` SET `minlevel`=32, `maxlevel`=32 WHERE `entry`=2091;
+-- Edwin Harly
+UPDATE `creature_template` SET `minlevel`=18, `maxlevel`=20 WHERE `entry`=2140;
+-- Rabid Thistle Bear
+UPDATE `creature_template` SET `minlevel`=13, `maxlevel`=14 WHERE `entry`=2164;
+-- Karos Razok
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=2226;
+-- Borgus Stoutarm
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=2299;
+-- Southshore Guard
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=2386;
+-- Zarise
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=2389;
+-- Daryl Stack
+UPDATE `creature_template` SET `minlevel`=56, `maxlevel`=56 WHERE `entry`=2399;
+-- Tarren Mill Deathguard
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=2405;
+-- Felicia Maline
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=2409;
+-- Darla Harris
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=2432;
+-- Southshore Crier
+UPDATE `creature_template` SET `minlevel`=32, `maxlevel`=32 WHERE `entry`=2435;
+-- Farmer Kent
+UPDATE `creature_template` SET `minlevel`=25, `maxlevel`=25 WHERE `entry`=2436;
+-- Saltwater Snapjaw
+UPDATE `creature_template` SET `minlevel`=49, `maxlevel`=50 WHERE `entry`=2505;
+-- Skymane Gorilla
+UPDATE `creature_template` SET `minlevel`=50, `maxlevel`=50 WHERE `entry`=2521;
+-- Jaguero Stalker
+UPDATE `creature_template` SET `minlevel`=50, `maxlevel`=50 WHERE `entry`=2522;
+-- Son of Arugal
+UPDATE `creature_template` SET `minlevel`=24, `maxlevel`=25 WHERE `entry`=2529;
+-- Fleet Master Firallon
+UPDATE `creature_template` SET `minlevel`=48, `maxlevel`=48 WHERE `entry`=2546;
+-- Captain Keelhaul
+UPDATE `creature_template` SET `minlevel`=46, `maxlevel`=47 WHERE `entry`=2548;
+-- Garr Salthoof
+UPDATE `creature_template` SET `minlevel`=41, `maxlevel`=43 WHERE `entry`=2549;
+-- Captain Stillwater
+UPDATE `creature_template` SET `minlevel`=45, `maxlevel`=46 WHERE `entry`=2550;
+-- Stromgarde Defender
+UPDATE `creature_template` SET `minlevel`=38, `maxlevel`=39 WHERE `entry`=2584;
+-- Stromgarde Vindicator
+UPDATE `creature_template` SET `minlevel`=39, `maxlevel`=40 WHERE `entry`=2585;
+-- Wenna Silkbeard
+UPDATE `creature_template` SET `minlevel`=28, `maxlevel`=30 WHERE `entry`=2679;
+-- King Magni Bronzebeard
+UPDATE `creature_template` SET `minlevel`=63, `maxlevel`=63 WHERE `entry`=2784;
+-- Drovnar Strongbrew
+UPDATE `creature_template` SET `minlevel`=38, `maxlevel`=40 WHERE `entry`=2812;
+-- Cedrik Prose
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=2835;
+-- Urda
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=2851;
+-- Gringer
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=2858;
+-- Gyll
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=2859;
+-- Gorrik
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=2861;
+-- Stonevault Seer
+UPDATE `creature_template` SET `minlevel`=39, `maxlevel`=40 WHERE `entry`=2892;
+-- Magregan Deepshadow
+UPDATE `creature_template` SET `minlevel`=38, `maxlevel`=38 WHERE `entry`=2932;
+-- Lanie Reed
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=2941;
+-- Tal
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=2995;
+-- Cairne Bloodhoof
+UPDATE `creature_template` SET `minlevel`=63, `maxlevel`=63 WHERE `entry`=3057;
+-- Honor Guard
+UPDATE `creature_template` SET `minlevel`=60, `maxlevel`=60 WHERE `entry`=3083;
+-- Bluffwatcher
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=3084;
+-- Makrura Snapclaw
+UPDATE `creature_template` SET `minlevel`=9, `maxlevel`=9 WHERE `entry`=3105;
+-- Gazz'uz
+UPDATE `creature_template` SET `minlevel`=14, `maxlevel`=14 WHERE `entry`=3204;
+-- Brave Proudsnout
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=3210;
+-- Brave Lightninghorn
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=3211;
+-- Brave Running Wolf
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=3213;
+-- Brave Greathoof
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=3214;
+-- Orgrimmar Grunt
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=3296;
+-- Grisha
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=3305;
+-- Doras
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=3310;
+-- Arch Druid Fandral Staghelm
+UPDATE `creature_template` SET `minlevel`=63, `maxlevel`=63 WHERE `entry`=3516;
+-- Andrew Hilbert
+UPDATE `creature_template` SET `minlevel`=18, `maxlevel`=20 WHERE `entry`=3556;
+-- Teldrassil Sentinel
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=3571;
+-- Dalaran Miner
+UPDATE `creature_template` SET `minlevel`=15, `maxlevel`=15 WHERE `entry`=3578;
+-- Devrak
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=3615;
+-- Deviate Stalker
+UPDATE `creature_template` SET `minlevel`=15, `maxlevel`=17 WHERE `entry`=3634;
+-- Trigore the Lasher
+UPDATE `creature_template` SET `minlevel`=19, `maxlevel`=19 WHERE `entry`=3652;
+-- Mad Magglish
+UPDATE `creature_template` SET `minlevel`=18, `maxlevel`=18 WHERE `entry`=3655;
+-- Boahn
+UPDATE `creature_template` SET `minlevel`=20, `maxlevel`=20 WHERE `entry`=3672;
+-- Blink Dragon
+UPDATE `creature_template` SET `minlevel`=26, `maxlevel`=27 WHERE `entry`=3815;
+-- Vesprystus
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=3838;
+-- Caylais Moonfeather
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=3841;
+-- Shandris Feathermoon
+UPDATE `creature_template` SET `minlevel`=62, `maxlevel`=62 WHERE `entry`=3936;
+-- Darnassus Sentinel
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=4262;
+-- Daelyshia
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=4267;
+-- Tharm
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=4312;
+-- Gorkas
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=4314;
+-- Nyse
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=4317;
+-- Thyssiana
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=4319;
+-- Baldruc
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=4321;
+-- Searing Hatchling
+UPDATE `creature_template` SET `minlevel`=41, `maxlevel`=42 WHERE `entry`=4323;
+-- Searing Whelp
+UPDATE `creature_template` SET `minlevel`=42, `maxlevel`=43 WHERE `entry`=4324;
+-- Firemane Scalebane
+UPDATE `creature_template` SET `minlevel`=43, `maxlevel`=44 WHERE `entry`=4328;
+-- Firemane Scout
+UPDATE `creature_template` SET `minlevel`=41, `maxlevel`=42 WHERE `entry`=4329;
+-- Firemane Ash Tail
+UPDATE `creature_template` SET `minlevel`=42, `maxlevel`=43 WHERE `entry`=4331;
+-- Firemane Flamecaller
+UPDATE `creature_template` SET `minlevel`=43, `maxlevel`=44 WHERE `entry`=4334;
+-- Brimgore
+UPDATE `creature_template` SET `minlevel`=45, `maxlevel`=45 WHERE `entry`=4339;
+-- Drywallow Daggermaw
+UPDATE `creature_template` SET `minlevel`=40, `maxlevel`=41 WHERE `entry`=4345;
+-- Bloodfen Raptor
+UPDATE `creature_template` SET `minlevel`=35, `maxlevel`=36 WHERE `entry`=4351;
+-- Bloodfen Razormaw
+UPDATE `creature_template` SET `minlevel`=39, `maxlevel`=40 WHERE `entry`=4356;
+-- Bloodfen Lashtail
+UPDATE `creature_template` SET `minlevel`=40, `maxlevel`=41 WHERE `entry`=4357;
+-- Mirefin Murloc
+UPDATE `creature_template` SET `minlevel`=35, `maxlevel`=36 WHERE `entry`=4359;
+-- Mirefin Oracle
+UPDATE `creature_template` SET `minlevel`=37, `maxlevel`=38 WHERE `entry`=4363;
+-- Darkmist Spider
+UPDATE `creature_template` SET `minlevel`=35, `maxlevel`=36 WHERE `entry`=4376;
+-- Darkmist Silkspinner
+UPDATE `creature_template` SET `minlevel`=38, `maxlevel`=39 WHERE `entry`=4379;
+-- Darkmist Widow
+UPDATE `creature_template` SET `minlevel`=40, `maxlevel`=40 WHERE `entry`=4380;
+-- Withervine Creeper
+UPDATE `creature_template` SET `minlevel`=35, `maxlevel`=36 WHERE `entry`=4382;
+-- Withervine Rager
+UPDATE `creature_template` SET `minlevel`=38, `maxlevel`=39 WHERE `entry`=4385;
+-- Young Murk Thresher
+UPDATE `creature_template` SET `minlevel`=39, `maxlevel`=41 WHERE `entry`=4388;
+-- Murk Thresher
+UPDATE `creature_template` SET `minlevel`=41, `maxlevel`=43 WHERE `entry`=4389;
+-- Elder Murk Thresher
+UPDATE `creature_template` SET `minlevel`=43, `maxlevel`=45 WHERE `entry`=4390;
+-- Mudrock Spikeshell
+UPDATE `creature_template` SET `minlevel`=37, `maxlevel`=38 WHERE `entry`=4397;
+-- Muckshell Clacker
+UPDATE `creature_template` SET `minlevel`=39, `maxlevel`=40 WHERE `entry`=4401;
+-- Muckshell Pincer
+UPDATE `creature_template` SET `minlevel`=41, `maxlevel`=42 WHERE `entry`=4403;
+-- Muckshell Scrabbler
+UPDATE `creature_template` SET `minlevel`=42, `maxlevel`=43 WHERE `entry`=4404;
+-- Teloren
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=4407;
+-- Darkfang Creeper
+UPDATE `creature_template` SET `minlevel`=38, `maxlevel`=39 WHERE `entry`=4412;
+-- Darkfang Venomspitter
+UPDATE `creature_template` SET `minlevel`=37, `maxlevel`=38 WHERE `entry`=4414;
+-- Giant Darkfang Spider
+UPDATE `creature_template` SET `minlevel`=40, `maxlevel`=41 WHERE `entry`=4415;
+-- Darnassian Protector
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=4423;
+-- Blackrock Summoner
+UPDATE `creature_template` SET `minlevel`=22, `maxlevel`=23 WHERE `entry`=4463;
+-- Bloodsail Deckhand
+UPDATE `creature_template` SET `minlevel`=43, `maxlevel`=44 WHERE `entry`=4505;
+-- Bloodsail Swabby
+UPDATE `creature_template` SET `minlevel`=42, `maxlevel`=44 WHERE `entry`=4506;
+-- Michael Garrett
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=4551;
+-- Booty Bay Bruiser
+UPDATE `creature_template` SET `minlevel`=57, `maxlevel`=57 WHERE `entry`=4624;
+-- Slitherblade Oracle
+UPDATE `creature_template` SET `minlevel`=34, `maxlevel`=35 WHERE `entry`=4718;
+-- Fallenroot Rogue
+UPDATE `creature_template` SET `minlevel`=21, `maxlevel`=22 WHERE `entry`=4789;
+-- Blackfathom Oracle
+UPDATE `creature_template` SET `minlevel`=21, `maxlevel`=22 WHERE `entry`=4803;
+-- Deadmire
+UPDATE `creature_template` SET `minlevel`=45, `maxlevel`=45 WHERE `entry`=4841;
+-- Shadowforge Ruffian
+UPDATE `creature_template` SET `minlevel`=36, `maxlevel`=37 WHERE `entry`=4845;
+-- Obsidian Golem
+UPDATE `creature_template` SET `minlevel`=38, `maxlevel`=38 WHERE `entry`=4872;
+-- Thrall
+UPDATE `creature_template` SET `minlevel`=63, `maxlevel`=63 WHERE `entry`=4949;
+-- Lady Jaina Proudmoore
+UPDATE `creature_template` SET `minlevel`=63, `maxlevel`=63 WHERE `entry`=4968;
+-- Enthralled Atal'ai
+UPDATE `creature_template` SET `minlevel`=45, `maxlevel`=46 WHERE `entry`=5261;
+-- Enraged Feral Scar
+UPDATE `creature_template` SET `minlevel`=44, `maxlevel`=45 WHERE `entry`=5295;
+-- Bloodroar the Stalker
+UPDATE `creature_template` SET `minlevel`=49, `maxlevel`=49 WHERE `entry`=5346;
+-- Deep Dweller
+UPDATE `creature_template` SET `minlevel`=47, `maxlevel`=47 WHERE `entry`=5467;
+-- Grunt Zuul
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=5546;
+-- Grunt Tharlak
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=5547;
+-- Ironforge Guard
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=5595;
+-- Killian Sanatha
+UPDATE `creature_template` SET `minlevel`=18, `maxlevel`=18 WHERE `entry`=5748;
+-- Aean Swiftriver
+UPDATE `creature_template` SET `minlevel`=25, `maxlevel`=25 WHERE `entry`=5797;
+-- Marcus Bel
+UPDATE `creature_template` SET `minlevel`=24, `maxlevel`=24 WHERE `entry`=5800;
+-- Margol the Rager
+UPDATE `creature_template` SET `minlevel`=48, `maxlevel`=48 WHERE `entry`=5833;
+-- Foreman Grills
+UPDATE `creature_template` SET `minlevel`=19, `maxlevel`=19 WHERE `entry`=5835;
+-- Twilight Dark Shaman
+UPDATE `creature_template` SET `minlevel`=47, `maxlevel`=48 WHERE `entry`=5860;
+-- Twilight Fire Guard
+UPDATE `creature_template` SET `minlevel`=48, `maxlevel`=49 WHERE `entry`=5861;
+-- Twilight Geomancer
+UPDATE `creature_template` SET `minlevel`=49, `maxlevel`=50 WHERE `entry`=5862;
+-- Corrupt Water Spirit
+UPDATE `creature_template` SET `minlevel`=19, `maxlevel`=19 WHERE `entry`=5897;
+-- Den Grunt
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=5952;
+-- Scorpok Stinger
+UPDATE `creature_template` SET `minlevel`=50, `maxlevel`=51 WHERE `entry`=5988;
+-- Breyk
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=6026;
+-- Diathorus the Seeker
+UPDATE `creature_template` SET `minlevel`=34, `maxlevel`=34 WHERE `entry`=6072;
+-- Baritanas Skyriver
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=6706;
+-- Thalon
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=6726;
+-- Stonevault Basher
+UPDATE `creature_template` SET `minlevel`=39, `maxlevel`=40 WHERE `entry`=6733;
+-- Jadefire Satyr
+UPDATE `creature_template` SET `minlevel`=49, `maxlevel`=50 WHERE `entry`=7105;
+-- Restless Shade
+UPDATE `creature_template` SET `minlevel`=58, `maxlevel`=60 WHERE `entry`=7370;
+-- Bera Stonehammer
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=7823;
+-- Bulkrek Ragefist
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=7824;
+-- Wildhammer Sentry
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=7865;
+-- Ambassador Bloodrage
+UPDATE `creature_template` SET `minlevel`=36, `maxlevel`=36 WHERE `entry`=7895;
+-- High Tinker Mekkatorque
+UPDATE `creature_template` SET `minlevel`=63, `maxlevel`=63 WHERE `entry`=7937;
+-- Feathermoon Sentinel
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=7939;
+-- Mulgore Protector
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=7975;
+-- Deathguard Elite
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=7980;
+-- Tyrande Whisperwind
+UPDATE `creature_template` SET `minlevel`=63, `maxlevel`=63 WHERE `entry`=7999;
+-- Guthrum Thunderfist
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=8018;
+-- Fyldren Moonfeather
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=8019;
+-- Shyn
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=8020;
+-- Camp Mojache Brave
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=8147;
+-- Kargath Grunt
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=8155;
+-- Murderous Blisterpaw
+UPDATE `creature_template` SET `minlevel`=44, `maxlevel`=44 WHERE `entry`=8208;
+-- Master Wood
+UPDATE `creature_template` SET `minlevel`=60, `maxlevel`=60 WHERE `entry`=8383;
+-- Obsidion
+UPDATE `creature_template` SET `minlevel`=52, `maxlevel`=52 WHERE `entry`=8400;
+-- Twilight Idolater
+UPDATE `creature_template` SET `minlevel`=49, `maxlevel`=51 WHERE `entry`=8419;
+-- Trade Master Kovic
+UPDATE `creature_template` SET `minlevel`=50, `maxlevel`=50 WHERE `entry`=8444;
+-- Clunk
+UPDATE `creature_template` SET `minlevel`=48, `maxlevel`=48 WHERE `entry`=8447;
+-- Blighted Surge
+UPDATE `creature_template` SET `minlevel`=54, `maxlevel`=55 WHERE `entry`=8519;
+-- Alexandra Constantine
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=8609;
+-- Kroum
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=8610;
+-- Overmaster Pyron
+UPDATE `creature_template` SET `minlevel`=52, `maxlevel`=52 WHERE `entry`=9026;
+-- Gadgetzan Bruiser
+UPDATE `creature_template` SET `minlevel`=57, `maxlevel`=57 WHERE `entry`=9460;
+-- Brackenwall Enforcer
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=10036;
+-- Lakeshire Guard
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=10037;
+-- Lady Sylvanas Windrunner
+UPDATE `creature_template` SET `minlevel`=63, `maxlevel`=63 WHERE `entry`=10181;
+-- Omusa Thunderhorn
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=10378;
+-- Vol'jin
+UPDATE `creature_template` SET `minlevel`=60, `maxlevel`=60 WHERE `entry`=10540;
+-- Gryfe
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=10583;
+-- Summoned Zombie
+UPDATE `creature_template` SET `minlevel`=53, `maxlevel`=54 WHERE `entry`=10698;
+-- Sindrayl
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=10897;
+-- Captured Arko'narin
+UPDATE `creature_template` SET `minlevel`=48, `maxlevel`=48 WHERE `entry`=11016;
+-- Maethrya
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=11138;
+-- Yugrek
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=11139;
+-- Bloodvenom Post Brave
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=11180;
+-- Everlook Bruiser
+UPDATE `creature_template` SET `minlevel`=57, `maxlevel`=57 WHERE `entry`=11190;
+-- Argent Defender
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=11194;
+-- Caer Darrow Citizen
+UPDATE `creature_template` SET `minlevel`=14, `maxlevel`=57 WHERE `entry`=11277;
+-- Warsong Shredder
+UPDATE `creature_template` SET `minlevel`=27, `maxlevel`=28 WHERE `entry`=11684;
+-- Cyclone Warrior
+UPDATE `creature_template` SET `minlevel`=57, `maxlevel`=59 WHERE `entry`=11745;
+-- Bunthen Plainswind
+UPDATE `creature_template` SET `minlevel`=60, `maxlevel`=60 WHERE `entry`=11798;
+-- Silva Fil'naveth
+UPDATE `creature_template` SET `minlevel`=60, `maxlevel`=60 WHERE `entry`=11800;
+-- Dendrite Starblaze
+UPDATE `creature_template` SET `minlevel`=60, `maxlevel`=60 WHERE `entry`=11802;
+-- Moonglade Warden
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=11822;
+-- Keeper Remulos
+UPDATE `creature_template` SET `minlevel`=62, `maxlevel`=62 WHERE `entry`=11832;
+-- Shardi
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=11899;
+-- Brakkar
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=11900;
+-- Andruk
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=11901;
+-- Great Bear Spirit
+UPDATE `creature_template` SET `minlevel`=60, `maxlevel`=60 WHERE `entry`=11956;
+-- Great Cat Spirit
+UPDATE `creature_template` SET `minlevel`=60, `maxlevel`=60 WHERE `entry`=11957;
+-- Ursol'lok
+UPDATE `creature_template` SET `minlevel`=32, `maxlevel`=32 WHERE `entry`=12037;
+-- Shadowglen Sentinel
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=12160;
+-- Shadowprey Guardian
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=12338;
+-- Wailing Spectre
+UPDATE `creature_template` SET `minlevel`=58, `maxlevel`=60 WHERE `entry`=12377;
+-- Damned Soul
+UPDATE `creature_template` SET `minlevel`=59, `maxlevel`=60 WHERE `entry`=12378;
+-- Unliving Caretaker
+UPDATE `creature_template` SET `minlevel`=59, `maxlevel`=60 WHERE `entry`=12379;
+-- Unliving Resident
+UPDATE `creature_template` SET `minlevel`=59, `maxlevel`=60 WHERE `entry`=12380;
+-- Jarrodenus
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=12577;
+-- Mishellena
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=12578;
+-- Bibilfaz Featherwhistle
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=12596;
+-- Vhulgra
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=12616;
+-- Khaelyn Steelwing
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=12617;
+-- Georgia
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=12636;
+-- Faustron
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=12740;
+-- Lieutenant Rachel Vaccar
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=12778;
+-- Ambassador Malcin
+UPDATE `creature_template` SET `minlevel`=36, `maxlevel`=36 WHERE `entry`=12865;
+-- Vahgruk
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=13177;
+-- Hydraxian Honor Guard
+UPDATE `creature_template` SET `minlevel`=57, `maxlevel`=57 WHERE `entry`=13322;
+-- Sergeant Durgen Stormpike
+UPDATE `creature_template` SET `minlevel`=58, `maxlevel`=58 WHERE `entry`=13777;
+-- Royal Dreadguard
+UPDATE `creature_template` SET `minlevel`=60, `maxlevel`=60 WHERE `entry`=13839;
+-- Accursed Slitherblade
+UPDATE `creature_template` SET `minlevel`=38, `maxlevel`=38 WHERE `entry`=14229;
+-- Burgle Eye
+UPDATE `creature_template` SET `minlevel`=38, `maxlevel`=38 WHERE `entry`=14230;
+-- Ripscale
+UPDATE `creature_template` SET `minlevel`=39, `maxlevel`=39 WHERE `entry`=14233;
+-- Hayoc
+UPDATE `creature_template` SET `minlevel`=41, `maxlevel`=41 WHERE `entry`=14234;
+-- The Rot
+UPDATE `creature_template` SET `minlevel`=44, `maxlevel`=44 WHERE `entry`=14235;
+-- Lord Angler
+UPDATE `creature_template` SET `minlevel`=44, `maxlevel`=44 WHERE `entry`=14236;
+-- Oozeworm
+UPDATE `creature_template` SET `minlevel`=42, `maxlevel`=42 WHERE `entry`=14237;
+-- Shanda the Spinner
+UPDATE `creature_template` SET `minlevel`=25, `maxlevel`=25 WHERE `entry`=14266;
+-- Kor'kron Elite
+UPDATE `creature_template` SET `minlevel`=60, `maxlevel`=60 WHERE `entry`=14304;
+-- Thief Catcher Shadowdelve
+UPDATE `creature_template` SET `minlevel`=60, `maxlevel`=60 WHERE `entry`=14363;
+-- Thief Catcher Farmountain
+UPDATE `creature_template` SET `minlevel`=60, `maxlevel`=60 WHERE `entry`=14365;
+-- Thief Catcher Thunderbrew
+UPDATE `creature_template` SET `minlevel`=60, `maxlevel`=60 WHERE `entry`=14367;
+-- Scout Stronghand
+UPDATE `creature_template` SET `minlevel`=60, `maxlevel`=60 WHERE `entry`=14375;
+-- Scout Manslayer
+UPDATE `creature_template` SET `minlevel`=60, `maxlevel`=60 WHERE `entry`=14376;
+-- Scout Tharr
+UPDATE `creature_template` SET `minlevel`=60, `maxlevel`=60 WHERE `entry`=14377;
+-- Huntress Skymane
+UPDATE `creature_template` SET `minlevel`=60, `maxlevel`=60 WHERE `entry`=14378;
+-- Huntress Ravenoak
+UPDATE `creature_template` SET `minlevel`=60, `maxlevel`=60 WHERE `entry`=14379;
+-- Huntress Leafrunner
+UPDATE `creature_template` SET `minlevel`=60, `maxlevel`=60 WHERE `entry`=14380;
+-- Griniblix the Spectator
+UPDATE `creature_template` SET `minlevel`=57, `maxlevel`=58 WHERE `entry`=14395;
+-- Officer Jaxon
+UPDATE `creature_template` SET `minlevel`=60, `maxlevel`=60 WHERE `entry`=14423;
+-- Gnawbone
+UPDATE `creature_template` SET `minlevel`=25, `maxlevel`=25 WHERE `entry`=14425;
+-- Officer Pomeroy
+UPDATE `creature_template` SET `minlevel`=60, `maxlevel`=60 WHERE `entry`=14438;
+-- Officer Brady
+UPDATE `creature_template` SET `minlevel`=60, `maxlevel`=60 WHERE `entry`=14439;
+-- Hunter Sagewind
+UPDATE `creature_template` SET `minlevel`=60, `maxlevel`=60 WHERE `entry`=14440;
+-- Hunter Ragetotem
+UPDATE `creature_template` SET `minlevel`=60, `maxlevel`=60 WHERE `entry`=14441;
+-- Horde Elite
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=14717;
+-- Revantusk Watcher
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=14730;
+-- Cloud Skydancer
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=15177;
+-- Runk Windtamer
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=15178;
+-- Cenarion Hold Infantry
+UPDATE `creature_template` SET `minlevel`=60, `maxlevel`=60 WHERE `entry`=15184;
+-- Horde Warbringer
+UPDATE `creature_template` SET `minlevel`=60, `maxlevel`=60 WHERE `entry`=15350;
+-- Alliance Brigadier General
+UPDATE `creature_template` SET `minlevel`=60, `maxlevel`=60 WHERE `entry`=15351;
+-- Stormwind Reveler
+UPDATE `creature_template` SET `minlevel`=1, `maxlevel`=60 WHERE `entry`=15694;
+-- GONG BOY DND DNR
+UPDATE `creature_template` SET `minlevel`=2, `maxlevel`=10 WHERE `entry`=15801;
+-- Steamwheedle Bruiser
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=16096;
+-- Gremnik Rizzlesprang
+UPDATE `creature_template` SET `minlevel`=1, `maxlevel`=1 WHERE `entry`=16123;
+-- Bragok
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=16227;
+-- Argent Sentry
+UPDATE `creature_template` SET `minlevel`=60, `maxlevel`=60 WHERE `entry`=16378;
+-- Midsummer Celebrant
+UPDATE `creature_template` SET `minlevel`=1, `maxlevel`=60 WHERE `entry`=16781;
+-- Goblin Commoner
+UPDATE `creature_template` SET `minlevel`=60, `maxlevel`=60 WHERE `entry`=20102;
+-- Gorrim
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=22931;
+-- Suralais Farwind
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=22935;
+-- Dyslix Silvergrub
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=23612;
+-- Nizzle
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=24366;
+-- Alicia
+UPDATE `creature_template` SET `minlevel`=60, `maxlevel`=60 WHERE `entry`=24729;
+-- Steam Tank Engineer
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=29016;
+-- Dockhand
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=29019;
+-- Stormwind Cannoneer
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=29088;
+-- Refurbished Steam Tank
+UPDATE `creature_template` SET `minlevel`=60, `maxlevel`=60 WHERE `entry`=29144;
+-- Stormwind Dock Worker
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=29152;
+-- Thargold Ironwing
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=29154;
+-- Apothecary Karlov
+UPDATE `creature_template` SET `minlevel`=61, `maxlevel`=61 WHERE `entry`=29346;
+-- King Varian Wrynn
+UPDATE `creature_template` SET `minlevel`=63, `maxlevel`=63 WHERE `entry`=29611;
+-- Stormwind Harbor Guard
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=29712;
+-- Benik Boltshear
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=29725;
+-- Walter Soref
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=29728;
+-- Thrall
+UPDATE `creature_template` SET `minlevel`=63, `maxlevel`=63 WHERE `entry`=31412;
+-- Orgrimmar Grunt
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=31416;
+-- Lady Sylvanas Windrunner
+UPDATE `creature_template` SET `minlevel`=63, `maxlevel`=63 WHERE `entry`=31419;
+-- Doras
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=31426;
+-- Overlord Runthak
+UPDATE `creature_template` SET `minlevel`=60, `maxlevel`=60 WHERE `entry`=31431;
+-- Warsong Battleguard
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=31564;
+-- Alliance Siege Vehicle
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=31638;
+-- Vol'jin
+UPDATE `creature_template` SET `minlevel`=63, `maxlevel`=63 WHERE `entry`=31649;
+-- Horde Demolisher
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=31652;
+-- Warsong Battleguard
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=31739;
+-- Lady Jaina Proudmoore
+UPDATE `creature_template` SET `minlevel`=63, `maxlevel`=63 WHERE `entry`=32346;
+-- Thrall
+UPDATE `creature_template` SET `minlevel`=63, `maxlevel`=63 WHERE `entry`=32363;
+-- Lady Sylvanas Windrunner
+UPDATE `creature_template` SET `minlevel`=63, `maxlevel`=63 WHERE `entry`=32365;
+-- Kor'kron Elite
+UPDATE `creature_template` SET `minlevel`=60, `maxlevel`=60 WHERE `entry`=32367;
+-- Broll Bearmantle
+UPDATE `creature_template` SET `minlevel`=60, `maxlevel`=60 WHERE `entry`=32376;
+-- Valeera Sanguinar
+UPDATE `creature_template` SET `minlevel`=60, `maxlevel`=60 WHERE `entry`=32378;
+-- Stormwind Elite
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=32387;
+-- Alliance Flying Machine
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=32388;
+-- King Varian Wrynn
+UPDATE `creature_template` SET `minlevel`=63, `maxlevel`=63 WHERE `entry`=32401;
+-- Lady Jaina Proudmoore
+UPDATE `creature_template` SET `minlevel`=63, `maxlevel`=63 WHERE `entry`=32402;
+-- Thrall
+UPDATE `creature_template` SET `minlevel`=63, `maxlevel`=63 WHERE `entry`=32518;
+-- Kor'kron Overseer
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=36213;
+-- Overseer Kraggosh
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=36217;
+-- Dark Ranger Clea
+UPDATE `creature_template` SET `minlevel`=60, `maxlevel`=60 WHERE `entry`=36224;
+-- Dark Ranger Anya
+UPDATE `creature_template` SET `minlevel`=60, `maxlevel`=60 WHERE `entry`=36225;
+-- Dark Ranger Cyndia
+UPDATE `creature_template` SET `minlevel`=60, `maxlevel`=60 WHERE `entry`=36226;
+-- Bragor Bloodfist
+UPDATE `creature_template` SET `minlevel`=60, `maxlevel`=60 WHERE `entry`=36273;
+-- Sentinel Stillbough
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=36481;
+-- Aleric Hawkins
+UPDATE `creature_template` SET `minlevel`=60, `maxlevel`=60 WHERE `entry`=36517;
+-- Frax Bucketdrop
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=37888;
+-- Timothy Cunningham
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=37915;
+-- Gnomeregan Medic
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=39275;
+-- Drill Sergeant Steamcrank
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=39368;
+-- Pilot Muzzlesprock
+UPDATE `creature_template` SET `minlevel`=60, `maxlevel`=60 WHERE `entry`=39386;
+-- Captain Tread Sparknozzle
+UPDATE `creature_template` SET `minlevel`=55, `maxlevel`=55 WHERE `entry`=39675;


### PR DESCRIPTION
Update creature templates to fit with a 1-60 level set up. Values gathered by comparing databases of AC and vMaNGOS.

If any creatures are removed from the world, they should be removed from this list too. They also need to be changed for a 60-70 set up and reset for a 70-80 set up.