### PR TITLE
chore(disables): Split T6 and move Magister's Terrace

### DIFF
--- a/65-69/disables.sql
+++ b/65-69/disables.sql
@@ -1,2 +1,2 @@
 -- 65-69 level range
-DELETE FROM `disables` WHERE `entry` IN (269, 540, 545, 552, 553, 554, 555, 556, 585);
+DELETE FROM `disables` WHERE `entry` IN (269, 540, 545, 552, 553, 554, 555, 556);

--- a/70/disables.sql
+++ b/70/disables.sql
@@ -2,7 +2,7 @@
 DELETE FROM `disables` WHERE `entry` IN (532, 544, 565);
 
 -- 70 level range - Tier 5
-DELETE FROM `disables` WHERE `entry` IN (548, 550);
+DELETE FROM `disables` WHERE `entry` IN (548, 550, 585);
 
 -- 70 level range - Tier 6
 DELETE FROM `disables` WHERE `entry` IN (534, 564, 568, 580);

--- a/70/disables.sql
+++ b/70/disables.sql
@@ -2,7 +2,13 @@
 DELETE FROM `disables` WHERE `entry` IN (532, 544, 565);
 
 -- 70 level range - Tier 5
-DELETE FROM `disables` WHERE `entry` IN (548, 550, 585);
+DELETE FROM `disables` WHERE `entry` IN (548, 550);
 
--- 70 level range - Tier 6
-DELETE FROM `disables` WHERE `entry` IN (534, 564, 568, 580);
+-- 70 level range - Tier 6 (Mount Hyjal)
+DELETE FROM `disables` WHERE `entry` IN (534);
+
+-- 70 level range - Tier 6 (Black Temple + Magister's Terrace)
+DELETE FROM `disables` WHERE `entry` IN (564, 585);
+
+-- 70 level range - Tier 6 (Sunwell Plateu + Zul Aman)
+DELETE FROM `disables` WHERE `entry` IN (568, 580);


### PR DESCRIPTION
Magister's Terrace was released as a catch-up dungeon alongside T6, just before Sunwell Plateau.