### PR TITLE
chore(disables): split 50/59 bracket

### DIFF
--- a/50-59/disables.sql
+++ b/50-59/disables.sql
@@ -1,2 +1,5 @@
--- 50-59 level range
-DELETE FROM `disables` WHERE `entry` IN (230, 429, 229, 289, 329);
+-- 50-59 level range (BRD, Dire Maul, Scholomance, Stratholme)
+DELETE FROM `disables` WHERE `entry` IN (230, 429, 289, 329);
+
+-- 50-59 level range (LBRS / UBRS)
+DELETE FROM `disables` WHERE `entry` IN (229);


### PR DESCRIPTION
In the 40-49 bracket we released BRD as a highlight. This PR serves to create the same effect for the 50-59 bracket from LBRS/UBRS.