### PR TITLE
Disable quest 8283

### DIFF
--- a/50-59/disables.sql
+++ b/50-59/disables.sql
@@ -1,2 +1,5 @@
 -- 50-59 level range (BRD, Dire Maul, Scholomance, Stratholme)
 DELETE FROM `disables` WHERE `entry` IN (230, 429, 289, 329);
+
+-- Quest: Wanted - Deathclasp, Terror of the Sands
+DELETE FROM `disables` WHERE `sourceType`=1 AND `entry`=8283;


### PR DESCRIPTION
Since the npc was momentarily removed by the progression, we also disabled the quest, to avoid confusing players looking for the npc.