### PR TITLE
Update Ahune loot bunny smart script.

### DIFF
--- a/src/Bracket_1_19/sql/world/progression_1_19_world_event_Ahune.sql
+++ b/src/Bracket_1_19/sql/world/progression_1_19_world_event_Ahune.sql
@@ -30,3 +30,9 @@ UPDATE `item_template` SET `RequiredLevel` = 65 WHERE (`entry` = 35723);
 
 UPDATE `creature_template` SET `MaxLevel` = 70, `MinLevel` = 70 WHERE `entry` IN (25755, 25756, 25757, 26340, 26341, 26342, 26339, 25865, 40446);
 UPDATE `creature_template` SET `MaxLevel` = 72, `MinLevel` = 72 WHERE `entry` IN (25740, 26338, 26865, 26339);
+
+-- Summon Loot Bunny SAI
+DELETE FROM `smart_scripts` WHERE `entryorguid` = 25746 AND `source_type` = 0 AND `id` = 1;
+INSERT INTO `smart_scripts` (`entryorguid`,`source_type`,`id`,`link`,`event_type`,`event_phase_mask`,`event_chance`,`event_flags`,`event_param1`,`event_param2`,`event_param3`,`event_param4`,`action_type`,`action_param1`,`action_param2`,`action_param3`,`action_param4`,`action_param5`,`action_param6`,`target_type`,`target_param1`,`target_param2`,`target_param3`,`target_x`,`target_y`,`target_z`,`target_o`,`comment`) VALUES
+(25746,0,1,0,8,0,100,2,45941,0,0,0,11,45939,0,0,0,0,0,1,0,0,0,0,0,0,0,'[PH] Ahune Loot Loc Bunny - On SpellHit - Cast \'Summon Loot\'');
+UPDATE `smart_scripts` SET `event_flags` = 4 WHERE `entryorguid` = 25746 AND `source_type` = 0 AND `id` = 0;

--- a/src/Bracket_80_1/sql/world/progression_1_19_world_event_Ahune_down.sql
+++ b/src/Bracket_80_1/sql/world/progression_1_19_world_event_Ahune_down.sql
@@ -27,3 +27,7 @@ UPDATE `item_template` SET `RequiredLevel` = 75 WHERE (`entry` = 35723);
 
 UPDATE `creature_template` SET `MaxLevel` = 80, `MinLevel` = 80 WHERE `entry` IN (25755, 25756, 25757, 26340, 26341, 26342, 26339, 25865, 40446);
 UPDATE `creature_template` SET `MaxLevel` = 82, `MinLevel` = 82 WHERE `entry` IN (25740, 26338, 26865, 26339);
+
+-- Summon Loot Bunny SAI
+DELETE FROM `smart_scripts` WHERE `entryorguid` = 25746 AND `source_type` = 0 AND `id` = 1;
+UPDATE `smart_scripts` SET `event_flags` = 0 WHERE `entryorguid` = 25746 AND `source_type` = 0 AND `id` = 0;


### PR DESCRIPTION
Uses a separate spell in normal and heroic to summon the loot chest, this PR updates the smart script to use both spells in the instance.