### PR TITLE
Remove Naxxramas' 'Orb of Naxxramas' Sapphiron Teleport skip

### DIFF
--- a/src/Bracket_80_1/sql/world/progression_80_1_t7_orb_of_naxxramas.sql
+++ b/src/Bracket_80_1/sql/world/progression_80_1_t7_orb_of_naxxramas.sql
@@ -1,0 +1,5 @@
+-- Hide gameobjects
+UPDATE `gameobject` SET `phasemask` = 16384 WHERE `id` IN (
+202277, -- Orb of Naxxramas - Teleport to Sapphiron
+202278 -- Orb of Naxxramas - Teleport from Sapphiron
+);

--- a/src/Bracket_80_4_2/sql/world/progression_80_4_2_t7_orb_of_naxxramas.sql
+++ b/src/Bracket_80_4_2/sql/world/progression_80_4_2_t7_orb_of_naxxramas.sql
@@ -1,0 +1,5 @@
+-- Restore gameobjects
+UPDATE `gameobject` SET `phasemask` = 1 WHERE `id` IN (
+202277, -- Orb of Naxxramas - Teleport to Sapphiron
+202278 -- Orb of Naxxramas - Teleport from Sapphiron
+);


### PR DESCRIPTION

Added in patch 3.3.0

> The Orb of Naxxramas is an object to bypass the requirement of the wings to be cleared. The orb teleporting without wings cleared is correct. It should only be clickable outside of combat.

See https://wowpedia.fandom.com/wiki/Patch_3.3.0

[Naxxramas](https://wowpedia.fandom.com/wiki/Naxxramas)

Players no longer need to kill the final bosses in all four wings of this dungeon in order to teleport to [Sapphiron](https://wowpedia.fandom.com/wiki/Sapphiron_(tactics)). Teleportation orbs have been added to allow players access back and forth from [Sapphiron's lair](https://wowpedia.fandom.com/wiki/Sapphiron%27s_Lair).

---------------

Wrath Classic: days before Ulduar opened
https://www.wowhead.com/wotlk/news/skip-to-frostwyrm-lair-in-naxxramas-wotlk-classic-331018
 Posted 2023/01/17 at 12:45 PM 

19 January 2023: [Ulduar](https://wowpedia.fandom.com/wiki/Ulduar) raid & [Titan Rune Dungeon: Defense Protocol Alpha](https://wowpedia.fandom.com/wiki/Titan_Rune_Dungeon) open

Timeline https://wowpedia.fandom.com/wiki/World_of_Warcraft:_Wrath_of_the_Lich_King_Classic
