### PR TITLE
fix(DB): OS 10-man emblems drop Heroism instead of Valor

### DIFF
--- a/src/Bracket_80_1_3/sql/world/progression_80_1_3_obsidian_sanctum_emblems.sql
+++ b/src/Bracket_80_1_3/sql/world/progression_80_1_3_obsidian_sanctum_emblems.sql
@@ -1,21 +1,14 @@
--- Obsidian Sanctum drakes: Heroism -> Valor
--- Shadron (10N: 30451, 25N: 31520)
--- Vesperon (10N: 30449, 25N: 31535)
--- Tenebron (10N: 30452, 25N: 31534)
+-- Obsidian Sanctum 25-man drakes: Heroism -> Valor
+-- Shadron 25N: 31520, Vesperon 25N: 31535, Tenebron 25N: 31534
+-- (10-man drakes remain at Heroism from Bracket_80_1_2 blanket conversion)
 UPDATE `creature_loot_template`
 SET `Item` = 40753, `Comment` = 'Emblem of Valor'
-WHERE `Entry` IN (30451, 31520, 30449, 31535, 30452, 31534)
+WHERE `Entry` IN (31520, 31535, 31534)
 AND `Item` = 40752;
 
--- Sartharion 10M: Heroism -> Valor
-UPDATE `creature_loot_template`
-SET `Item` = 40753, `Comment` = 'Emblem of Valor'
-WHERE `Entry` = 28860
-AND `Item` = 40752;
-
--- Satchel of Spoils (10M): Triumph -> Valor
+-- Satchel of Spoils (10M): Triumph -> Heroism
 UPDATE `item_loot_template`
-SET `Item` = 40753, `Comment` = 'Satchel of Spoils - Emblem of Valor'
+SET `Item` = 40752, `Comment` = 'Satchel of Spoils - Emblem of Heroism'
 WHERE `Entry` = 43347
 AND `Item` = 47241;
 

--- a/src/Bracket_80_2/sql/world/progression_80_1_3_obsidian_sanctum_emblems_down.sql
+++ b/src/Bracket_80_2/sql/world/progression_80_1_3_obsidian_sanctum_emblems_down.sql
@@ -1,23 +1,28 @@
--- Obsidian Sanctum drakes: Valor -> Triumph
--- Shadron (10N: 30451, 25N: 31520)
--- Vesperon (10N: 30449, 25N: 31535)
--- Tenebron (10N: 30452, 25N: 31534)
+-- Obsidian Sanctum 10-man drakes: Heroism -> Triumph
+-- Shadron 10N: 30451, Vesperon 10N: 30449, Tenebron 10N: 30452
 UPDATE `creature_loot_template`
 SET `Item` = 47241, `Comment` = 'Emblem of Triumph'
-WHERE `Entry` IN (30451, 31520, 30449, 31535, 30452, 31534)
+WHERE `Entry` IN (30451, 30449, 30452)
+AND `Item` = 40752;
+
+-- Obsidian Sanctum 25-man drakes: Valor -> Triumph
+-- Shadron 25N: 31520, Vesperon 25N: 31535, Tenebron 25N: 31534
+UPDATE `creature_loot_template`
+SET `Item` = 47241, `Comment` = 'Emblem of Triumph'
+WHERE `Entry` IN (31520, 31535, 31534)
 AND `Item` = 40753;
 
--- Sartharion 10M: Valor -> Triumph
+-- Sartharion 10M: Heroism -> Triumph
 UPDATE `creature_loot_template`
 SET `Item` = 47241, `Comment` = 'Emblem of Triumph'
 WHERE `Entry` = 28860
-AND `Item` = 40753;
+AND `Item` = 40752;
 
--- Satchel of Spoils (10M): Valor -> Triumph
+-- Satchel of Spoils (10M): Heroism -> Triumph
 UPDATE `item_loot_template`
 SET `Item` = 47241, `Comment` = 'Satchel of Spoils - Emblem of Triumph'
 WHERE `Entry` = 43347
-AND `Item` = 40753;
+AND `Item` = 40752;
 
 -- Large Satchel of Spoils (25M): Valor -> Triumph
 UPDATE `item_loot_template`


### PR DESCRIPTION
## Summary
- Keep Obsidian Sanctum 10-man drake drops (Shadron 30451, Vesperon 30449, Tenebron 30452) at Emblem of Heroism during the Naxxramas bracket
- Keep Sartharion 10M (28860) and the 10M Satchel of Spoils (43347) at Emblem of Heroism as well
- Only 25-man drakes (31520, 31535, 31534) and the Large Satchel of Spoils (43346) get upgraded to Emblem of Valor
- Update the Ulduar revert file to restore Triumph from the correct source emblem per entry (Heroism for 10-man, Valor for 25-man)

## Test plan
- [ ] Apply Bracket_80_1_3 SQL and verify 10-man OS drakes/Sartharion/Satchel drop Emblem of Heroism (40752)
- [ ] Verify 25-man OS drakes and Large Satchel drop Emblem of Valor (40753)
- [ ] Apply Bracket_80_2 SQL and verify all OS emblem drops revert to Emblem of Triumph (47241)

🤖 Generated with [Claude Code](https://claude.com/claude-code)