### PR TITLE
feat(DB): Restore Glory of the Raider mount rewards

### DIFF
--- a/src/Bracket_80_1_1/sql/world/progression_80_1_achievement_reward_glory_of_the_raider.sql
+++ b/src/Bracket_80_1_1/sql/world/progression_80_1_achievement_reward_glory_of_the_raider.sql
@@ -1,0 +1,8 @@
+-- Restore Glory of the Raider (10/25) mount rewards removed in Patch 3.1.
+-- Achievement 2137 -> Reins of the Plagued Proto-Drake (item 44175)
+-- Achievement 2138 -> Reins of the Black Proto-Drake  (item 44164)
+-- Sender 26917 = Alexstrasza the Life-Binder.
+DELETE FROM `achievement_reward` WHERE `ID` IN (2137, 2138);
+INSERT INTO `achievement_reward` (`ID`, `TitleA`, `TitleH`, `ItemID`, `Sender`, `Subject`, `Body`, `MailTemplateID`) VALUES
+(2137, 0, 0, 44175, 26917, 'Glory of the Raider', 'Champion,$B$BWord has traveled to Wyrmrest Temple of the great deeds you have accomplished since arriving in Northrend.$B$BYour bravery should not go unrecognized. Please accept this gift on behalf of the Aspects. Together we shall rid Azeroth of evil, once and for eternity.$B$BAlexstrasza the Life-Binder', 0),
+(2138, 0, 0, 44164, 26917, 'Glory of the Raider', 'Champion,$B$BWord has traveled to Wyrmrest Temple of the great deeds you have accomplished since arriving in Northrend.$B$BYour bravery should not go unrecognized. Please accept this gift on behalf of the Aspects. Together we shall rid Azeroth of evil, once and for eternity.$B$BAlexstrasza the Life-Binder', 0);

--- a/src/Bracket_80_2/sql/world/progression_80_1_achievement_reward_glory_of_the_raider_down.sql
+++ b/src/Bracket_80_2/sql/world/progression_80_1_achievement_reward_glory_of_the_raider_down.sql
@@ -1,0 +1,4 @@
+-- Revert Glory of the Raider (10/25) mount rewards at Patch 3.1 (Ulduar).
+-- Matches retail: the Plagued and Black Proto-Drake rewards were removed
+-- when Ulduar went live.
+DELETE FROM `achievement_reward` WHERE `ID` IN (2137, 2138);


### PR DESCRIPTION
## Summary
- Restores the Plagued Proto-Drake (item 44175) and Black Proto-Drake (item 44164) rewards for Glory of the Raider 10/25 (achievements 2137/2138), which retail mailed out from Alexstrasza pre-3.1 and which AzerothCore's base `achievement_reward` data no longer contains.
- Adds the insert in `Bracket_80_1_1` so servers in the Wrath pre-Ulduar tier can grant the mounts.
- Adds a matching `_down` file in `Bracket_80_2` that deletes the rows when Ulduar unlocks, mirroring retail's Patch 3.1 removal.

Mail subject/body restored from wiki preservation of the original Alexstrasza letter; sender `26917` matches other Wrath achievement rewards already in the table.

## Test plan
- [ ] Enable only through `Bracket_80_1_1`; complete achievement 2137 or 2138 → mail with correct mount item arrives from Alexstrasza
- [ ] Advance into `Bracket_80_2`; verify both rows are removed from `achievement_reward` and the rewards no longer mail on completion
- [ ] `achievement_reward` row for 2136 (Glory of the Hero) stays intact across both brackets
- [ ] AI tool usage: Claude Code (Opus 4.6) assisted with research and SQL drafting

🤖 Generated with [Claude Code](https://claude.com/claude-code)