### PR TITLE
fix: comment out remaining npc_trainer SQL in Bracket_70_6_3

### DIFF
--- a/src/Bracket_70_6_3/sql/world/progression_0_npc_trainer_flying_down.sql
+++ b/src/Bracket_70_6_3/sql/world/progression_0_npc_trainer_flying_down.sql
@@ -1,9 +1,9 @@
 -- Update cost for normal flying back to original value
-UPDATE `npc_trainer` SET `MoneyCost`=2500000, `ReqLevel`=60 WHERE `ID`=202011 AND `SpellID`=34090;
+-- UPDATE `npc_trainer` SET `MoneyCost`=2500000, `ReqLevel`=60 WHERE `ID`=202011 AND `SpellID`=34090;
 
 -- Restore Epic Flight Form from trainers
-DELETE FROM `npc_trainer` WHERE `ID`=200006 AND `SpellID`=40120;
-INSERT INTO `npc_trainer` (`ID`, `SpellID`, `MoneyCost`, `ReqSkillLine`, `ReqSkillRank`, `ReqLevel`, `ReqSpell`) VALUES (200006, 40120, 200000, 762, 300, 71, 0);
+-- DELETE FROM `npc_trainer` WHERE `ID`=200006 AND `SpellID`=40120;
+-- INSERT INTO `npc_trainer` (`ID`, `SpellID`, `MoneyCost`, `ReqSkillLine`, `ReqSkillRank`, `ReqLevel`, `ReqSpell`) VALUES (200006, 40120, 200000, 762, 300, 71, 0);
 
 -- Restore Flight Form to 60
-UPDATE `npc_trainer` SET `ReqLevel`=60 WHERE `ID`=200006 AND `SpellID`=33950;
+-- UPDATE `npc_trainer` SET `ReqLevel`=60 WHERE `ID`=200006 AND `SpellID`=33950;


### PR DESCRIPTION
## Problem

The `npc_trainer` table was removed from the core in the trainer-system refactor (world DB update `2025_12_29_12.sql`, which migrates to `trainer` / `trainer_spell` / `creature_default_trainer`). A follow-up sweep in this module (`ef6eeb6`, `b7ed663`, `cf97553`) commented out the obsolete `npc_trainer` SQL — but one file was missed:

`src/Bracket_70_6_3/sql/world/progression_0_npc_trainer_flying_down.sql`

It still has 4 active `npc_trainer` statements, so on a server running current core the world DB updater aborts:

```
ERROR 1146 (42S02): Table 'acore_world.npc_trainer' doesn't exist
FATAL [sql.updates] Applying of file '.../Bracket_70_6_3/sql/world/progression_0_npc_trainer_flying_down.sql' to database 'acore_world' failed!
```

and the worldserver never reaches "ready".

## Fix

Comment out the four statements, matching how the sibling "up" file `src/Bracket_0/sql/world/progression_0_npc_trainer_flying.sql` was already disabled. Since the "up" is disabled there is nothing for this "down" to revert, so this is purely a cleanup of dead SQL — no behavior change.

## Testing

Applied on a server at current core: the world DB updater now applies this file (and the other commented trainer files) cleanly, the update batch completes, and the worldserver reaches `ready`.
