### PR TITLE
fix(DB): Gate WotLK Ahune 232 loot behind ToC phase

### DIFF
--- a/src/Bracket_80_1_1/sql/world/progression_1_19_world_event_Ahune_down.sql
+++ b/src/Bracket_80_1_1/sql/world/progression_1_19_world_event_Ahune_down.sql
@@ -1,25 +1,17 @@
--- Revert Ahune loot to WotLK-Era
+-- Revert Ahune to the WotLK-era encounter (level 80) at the first WotLK phase.
+-- The ilvl-232 cloaks are withheld here and unlocked in the Trial of the Crusader
+-- phase (Bracket_80_3), since their item level matches phase-3 normal raid gear.
 DELETE FROM `gameobject_loot_template` WHERE (`Entry` IN (28682, 28683));
 INSERT INTO `gameobject_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
 (28682, 35498, 0, 3, 0, 1, 0, 1, 1, 'Ice Chest - Formula: Enchant Weapon - Deathfrost'),
 (28682, 35557, 0, 100, 0, 1, 0, 2, 2, 'Ice Chest - Huge Snowball'),
 (28682, 35720, 0, 3, 0, 1, 0, 6, 6, 'Ice Chest - Lord of Frost\'s Private Label'),
 (28682, 35723, 0, 100, 0, 1, 0, 1, 1, 'Ice Chest - Shards of Ahune'),
-(28682, 54801, 0, 0, 0, 1, 1, 1, 1, 'Ice Chest - Icebound Cloak'),
-(28682, 54802, 0, 0, 0, 1, 1, 1, 1, 'Ice Chest - The Frost Lord\'s War Cloak'),
-(28682, 54803, 0, 0, 0, 1, 1, 1, 1, 'Ice Chest - The Frost Lord\'s Battle Shroud'),
-(28682, 54804, 0, 0, 0, 1, 1, 1, 1, 'Ice Chest - Shroud of Winter\'s Chill'),
-(28682, 54805, 0, 0, 0, 1, 1, 1, 1, 'Ice Chest - Cloak of the Frigid Winds'),
 
 (28683, 35498, 0, 3, 0, 1, 0, 1, 1, 'Ice Chest - Formula: Enchant Weapon - Deathfrost'),
 (28683, 35557, 0, 28, 0, 1, 0, 1, 2, 'Ice Chest - Huge Snowball'),
 (28683, 35720, 0, 3, 0, 1, 0, 5, 6, 'Ice Chest - Lord of Frost\'s Private Label'),
-(28683, 35723, 0, 100, 0, 1, 0, 1, 1, 'Ice Chest - Shards of Ahune'),
-(28683, 54801, 0, 0, 0, 1, 1, 1, 1, 'Ice Chest - Icebound Cloak'),
-(28683, 54802, 0, 0, 0, 1, 1, 1, 1, 'Ice Chest - The Frost Lord\'s War Cloak'),
-(28683, 54803, 0, 0, 0, 1, 1, 1, 1, 'Ice Chest - The Frost Lord\'s Battle Shroud'),
-(28683, 54804, 0, 0, 0, 1, 1, 1, 1, 'Ice Chest - Shroud of Winter\'s Chill'),
-(28683, 54805, 0, 0, 0, 1, 1, 1, 1, 'Ice Chest - Cloak of the Frigid Winds');
+(28683, 35723, 0, 100, 0, 1, 0, 1, 1, 'Ice Chest - Shards of Ahune');
 
 -- Change quest level requirement back to 75
 UPDATE `quest_template` SET `MinLevel` = 75 WHERE (`ID` = 11972);

--- a/src/Bracket_80_3/sql/world/progression_80_3_world_event_Ahune_cloaks.sql
+++ b/src/Bracket_80_3/sql/world/progression_80_3_world_event_Ahune_cloaks.sql
@@ -1,0 +1,26 @@
+-- Unlock the ilvl-232 Ahune cloaks once the Trial of the Crusader phase makes
+-- their item level appropriate. Until this bracket the Ice Chests drop only the
+-- seasonal/emblem rewards set in Bracket_80_1_1.
+DELETE FROM `gameobject_loot_template` WHERE (`Entry` IN (28682, 28683));
+INSERT INTO `gameobject_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(28682, 35498, 0, 3, 0, 1, 0, 1, 1, 'Ice Chest - Formula: Enchant Weapon - Deathfrost'),
+(28682, 35557, 0, 100, 0, 1, 0, 2, 2, 'Ice Chest - Huge Snowball'),
+(28682, 35720, 0, 3, 0, 1, 0, 6, 6, 'Ice Chest - Lord of Frost\'s Private Label'),
+(28682, 35723, 0, 100, 0, 1, 0, 1, 1, 'Ice Chest - Shards of Ahune'),
+(28682, 54801, 0, 0, 0, 1, 1, 1, 1, 'Ice Chest - Icebound Cloak'),
+(28682, 54802, 0, 0, 0, 1, 1, 1, 1, 'Ice Chest - The Frost Lord\'s War Cloak'),
+(28682, 54803, 0, 0, 0, 1, 1, 1, 1, 'Ice Chest - The Frost Lord\'s Battle Shroud'),
+(28682, 54804, 0, 0, 0, 1, 1, 1, 1, 'Ice Chest - Shroud of Winter\'s Chill'),
+(28682, 54805, 0, 0, 0, 1, 1, 1, 1, 'Ice Chest - Cloak of the Frigid Winds'),
+(28682, 54806, 0, 0, 0, 1, 1, 1, 1, 'Ice Chest - Frostscythe of Lord Ahune'),
+
+(28683, 35498, 0, 3, 0, 1, 0, 1, 1, 'Ice Chest - Formula: Enchant Weapon - Deathfrost'),
+(28683, 35557, 0, 28, 0, 1, 0, 1, 2, 'Ice Chest - Huge Snowball'),
+(28683, 35720, 0, 3, 0, 1, 0, 5, 6, 'Ice Chest - Lord of Frost\'s Private Label'),
+(28683, 35723, 0, 100, 0, 1, 0, 1, 1, 'Ice Chest - Shards of Ahune'),
+(28683, 54801, 0, 0, 0, 1, 1, 1, 1, 'Ice Chest - Icebound Cloak'),
+(28683, 54802, 0, 0, 0, 1, 1, 1, 1, 'Ice Chest - The Frost Lord\'s War Cloak'),
+(28683, 54803, 0, 0, 0, 1, 1, 1, 1, 'Ice Chest - The Frost Lord\'s Battle Shroud'),
+(28683, 54804, 0, 0, 0, 1, 1, 1, 1, 'Ice Chest - Shroud of Winter\'s Chill'),
+(28683, 54805, 0, 0, 0, 1, 1, 1, 1, 'Ice Chest - Cloak of the Frigid Winds'),
+(28683, 54806, 0, 0, 0, 1, 1, 1, 1, 'Ice Chest - Frostscythe of Lord Ahune');


### PR DESCRIPTION
## Problem

The WotLK Ahune revert ([`progression_1_19_world_event_Ahune_down.sql`](https://github.com/azerothcore/mod-progression-system/blob/main/src/Bracket_80_1_1/sql/world/progression_1_19_world_event_Ahune_down.sql)) restored the ilvl-232 cloaks (`54801`-`54805`) at the **first** level-80 bracket (`80_1_1`, Naxxramas/EoE/OS). Item level 232 matches phase-3 normal-mode raid gear (Trial of the Crusader), so the cloaks were obtainable two phases early.

Separately, that revert restored **no weapon at all**: the TBC Frostscythe (`35514`) stopped dropping on transition to level 80, and the WotLK Frostscythe (`54806`, ilvl 232) was never added.

## Change

- **`80_1_1`** now restores only the WotLK encounter: level-80 creatures, the level-75 daily (`Shards of Ahune` → Frost Emblems, the correct phase-1 currency), and the seasonal/cosmetic drops. The epic cloaks are withheld.
- **`80_3`** (Trial of the Crusader) unlocks the ilvl-232 cloaks, where their item level fits.
- The WotLK `Frostscythe of Lord Ahune` (`54806`, ilvl 232) is added to the `80_3` loot, in the same guaranteed epic group as the cloaks (one random epic per kill, matching retail).

## Result

| Bracket | Ahune Ice Chest gear |
|---------|----------------------|
| `1_19` (TBC) | ilvl-110 cloaks/necks + scythe `35514`, Badge of Justice |
| `80_1_1` (Naxx, p1) | none — daily/emblems + seasonal cosmetics only |
| `80_3` (ToC, p3) | ilvl-232 cloaks `54801`-`54805` + scythe `54806` |

References: https://wowgaming.altervista.org/aowow/?item=54801

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Game Balance**
  * Adjusted Ahune seasonal event encounter loot progression across different game phases to align with intended progression rewards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->